### PR TITLE
Update faill all jobs query

### DIFF
--- a/jobs.md
+++ b/jobs.md
@@ -38,7 +38,7 @@ condor_status -autoformat Machine GalaxyGroup GalaxyDockerHack | grep hack | sor
 The following command is failing all jobs of the service-account user.
 
 ```bash
-gxadmin tsvquery jobs --user=service-account --nonterminal | awk '{print $1}' |  xargs -n 1 gxadmin local fail-job
+gxadmin tsvquery jobs --user=service-account --nonterminal | awk '{print $1}' |  xargs -I {} -n 1 gxadmin mutate fail-job {} --commit 
 ```
 
 ### fail all jobs on the nodes, in cases when condor_rm does not do the job

--- a/jobs.md
+++ b/jobs.md
@@ -38,7 +38,7 @@ condor_status -autoformat Machine GalaxyGroup GalaxyDockerHack | grep hack | sor
 The following command is failing all jobs of the service-account user.
 
 ```bash
-gxadmin query queue-details | grep  service-account | awk '{print $3}' |  xargs -I {} sh -c "gxadmin local fail-job {}"
+gxadmin tsvquery jobs --user=service-account --nonterminal | awk '{print $1}' |  xargs -n 1 gxadmin local fail-job
 ```
 
 ### fail all jobs on the nodes, in cases when condor_rm does not do the job


### PR DESCRIPTION
- `gxadmin query jobs` is probably a better query than queue-details
- tsvquery means `awk` behaves more properly, the current version I guess gets the header column and tries to fail that?
- Remove unnecessary `sh` call in xargs